### PR TITLE
Re-wrote excel.py to allow it to be used to write a worksheet to Exce…

### DIFF
--- a/functions/xml.py
+++ b/functions/xml.py
@@ -2,7 +2,7 @@ import hashlib
 import zipfile
 
 
-def list_of_xml_files(filename_path, file_name):
+def list_of_xml_files(filename_path):
     print("Processing word/document.xml for list of XML files.")
     with zipfile.ZipFile(filename_path, 'r') as zip_file:
         # list content of the DOCx file
@@ -11,7 +11,7 @@ def list_of_xml_files(filename_path, file_name):
             with zipfile.ZipFile(filename_path, 'r') as zip_ref:
                 with zip_ref.open(file_info.filename) as xml_file:
                     md5hash = hashlib.md5(xml_file.read()).hexdigest()
-            xml_files.append([file_name, file_info.filename, file_info.file_size, md5hash])
+            xml_files.append([file_info.filename, file_info.file_size, md5hash])
         return xml_files
 
 


### PR DESCRIPTION
…l by passing the correct parameters. Makes it more modular, calling the function anytime you need to write data to a worksheet. Previously, all worksheet writes were within the single function write_to_excel, making it cumbersome to maintain.